### PR TITLE
feat: add user notifications and dashboard statistics

### DIFF
--- a/bugboard/README.md
+++ b/bugboard/README.md
@@ -1,65 +1,125 @@
 # BugBoard - Plugin de WordPress
 
-## Descripción
-BugBoard es un plugin de WordPress para la gestión de tareas y bugs. Proporciona un sistema de gestión de tareas con un tablero personalizado en el panel de administración.
+Un tablero Kanban moderno para gestión de tareas y bugs en WordPress.
 
 ## Características
 
-### Funcionalidades Actuales
-- **Menú de Administración**: Menú principal "BugBoard" con icono de bug
-- **Submenú Tablero**: Vista del tablero (en construcción)
-- **Custom Post Type**: "Tareas" (slug: bug) para gestionar las tareas
-- **Interfaz en Español**: Todos los textos están en español
-
-### Custom Post Type "Tareas"
-- **Visibilidad**: Solo en el panel de administración (no público)
-- **Campos soportados**: Título, Editor, Autor
-- **Icono**: dashicons-bug
-- **Sin REST API**: No disponible para exportación
+- **Tablero Kanban** con columnas: Por Hacer, En Progreso, En Revisión, Completado
+- **Drag & Drop** fluido para mover tareas entre columnas
+- **Gestión de tareas** con título, descripción, prioridad, asignado y fecha límite
+- **Interfaz moderna** y responsiva
+- **Actualización optimista** de la UI
+- **Sincronización automática** con el servidor
+- **Sistema de usuarios** integrado con WordPress
 
 ## Instalación
 
-1. Copia la carpeta `bugboard` a `/wp-content/plugins/`
-2. Activa el plugin desde el panel de administración de WordPress
-3. El menú "BugBoard" aparecerá en el menú lateral del admin
+1. Sube la carpeta `bugboard` al directorio `/wp-content/plugins/` de tu instalación de WordPress
+2. Activa el plugin a través del menú 'Plugins' en WordPress
+3. Accede al tablero desde el menú 'BugBoard' en el panel de administración
 
-## Estructura del Plugin
+## Estructura de Base de Datos
 
-```
-bugboard/
-├── bugboard.php          # Archivo principal del plugin
-├── assets/
-│   └── css/
-│       └── admin.css     # Estilos del admin
-└── README.md             # Este archivo
-```
+El plugin crea las siguientes tablas personalizadas:
+
+### `wp_bugboard_tasks`
+- `id` - ID único de la tarea
+- `title` - Título de la tarea
+- `description` - Descripción detallada
+- `status` - Estado actual (por-hacer, en-progreso, en-revision, completado)
+- `priority` - Prioridad (baja, media, alta, critica)
+- `assignee_id` - ID del usuario asignado
+- `author_id` - ID del usuario que creó la tarea
+- `created_at` - Fecha de creación
+- `updated_at` - Fecha de última actualización
+- `due_date` - Fecha límite (opcional)
+- `estimated_hours` - Horas estimadas (opcional)
+
+### `wp_bugboard_comments`
+- `id` - ID único del comentario
+- `task_id` - ID de la tarea
+- `user_id` - ID del usuario que comentó
+- `comment` - Contenido del comentario
+- `created_at` - Fecha de creación
+
+### `wp_bugboard_attachments`
+- `id` - ID único del archivo
+- `task_id` - ID de la tarea
+- `filename` - Nombre del archivo
+- `filepath` - Ruta del archivo
+- `filesize` - Tamaño del archivo
+- `mime_type` - Tipo MIME
+- `uploaded_at` - Fecha de subida
 
 ## Uso
 
-### Acceso al Plugin
-1. Ve al panel de administración de WordPress
-2. Busca el menú "BugBoard" en el menú lateral
-3. Haz clic en "Tablero" para ver la vista del tablero
+### Crear una nueva tarea
+1. Haz clic en el botón "+" en cualquier columna
+2. Completa el formulario con los datos de la tarea
+3. Haz clic en "Guardar"
 
-### Gestión de Tareas
-1. En el menú lateral, busca "Tareas"
-2. Puedes crear, editar y gestionar las tareas desde ahí
+### Mover una tarea
+1. Haz clic y arrastra la tarea a la columna deseada
+2. Suelta la tarea en la nueva ubicación
+3. El estado se actualizará automáticamente
+
+### Editar una tarea
+1. Haz clic en el botón de editar (✏️) en la tarea
+2. Modifica los datos en el modal
+3. Haz clic en "Guardar"
+
+### Eliminar una tarea
+1. Haz clic en el botón de eliminar (🗑️) en la tarea
+2. Confirma la eliminación
 
 ## Desarrollo
 
-### Hooks Utilizados
-- `init`: Para registrar el Custom Post Type
-- `admin_menu`: Para añadir menús al admin
-- `admin_enqueue_scripts`: Para cargar estilos
-- `plugins_loaded`: Para inicializar el plugin
+### Estructura de archivos
+```
+bugboard/
+├── bugboard.php              # Archivo principal del plugin
+├── includes/
+│   ├── class-bugboard-activator.php    # Activación y creación de tablas
+│   ├── class-bugboard-tasks.php        # Manejo de tareas
+│   ├── class-bugboard-ajax.php         # Manejadores AJAX
+│   ├── class-bugboard-admin.php        # Interfaz de administración
+│   └── class-bugboard-tablero.php      # Tablero Kanban
+├── assets/
+│   ├── css/
+│   │   └── admin.css         # Estilos del admin
+│   └── js/
+│       └── tablero.js        # JavaScript del tablero
+└── README.md                 # Este archivo
+```
 
-### Funciones Principales
-- `BugBoard::register_bug_post_type()`: Registra el CPT
-- `BugBoard::add_admin_menu()`: Añade los menús
-- `BugBoard::bugboard_tablero_page()`: Renderiza la página del tablero
+### Hooks AJAX disponibles
+- `bugboard_get_tasks` - Obtener todas las tareas
+- `bugboard_get_task` - Obtener una tarea específica
+- `bugboard_create_task` - Crear una nueva tarea
+- `bugboard_update_task` - Actualizar una tarea
+- `bugboard_delete_task` - Eliminar una tarea
+- `bugboard_update_task_status` - Actualizar estado de tarea
+- `bugboard_get_users` - Obtener usuarios disponibles
 
-## Versión
-1.0.0
+## Requisitos
+
+- WordPress 5.0 o superior
+- PHP 7.4 o superior
+- MySQL 5.6 o superior
 
 ## Licencia
-GPL v2 or later 
+
+GPL v2 o posterior
+
+## Autor
+
+Tu Nombre - [tu-sitio.com](https://tu-sitio.com)
+
+## Changelog
+
+### 1.0.0
+- Versión inicial
+- Tablero Kanban funcional
+- Drag & drop implementado
+- Gestión completa de tareas
+- Interfaz moderna y responsiva 

--- a/bugboard/assets/css/admin.css
+++ b/bugboard/assets/css/admin.css
@@ -30,6 +30,40 @@
     margin-bottom: 20px;
 }
 
+/* ===== ESTADÍSTICAS ===== */
+
+.bugboard-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin: 20px 0;
+}
+
+.stat-card {
+    background: #fff;
+    border: 1px solid #e1e5e9;
+    border-radius: 8px;
+    padding: 20px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.stat-card h3 {
+    margin: 0 0 10px 0;
+    font-size: 16px;
+    color: #666;
+}
+
+.stat-number {
+    font-size: 32px;
+    font-weight: bold;
+    color: #0073aa;
+}
+
+.stat-card.total .stat-number {
+    color: #4caf50;
+}
+
 /* ===== TABLERO KANBAN ===== */
 
 .bugboard-tablero {
@@ -48,8 +82,11 @@
     border-radius: 8px;
     min-width: 300px;
     max-width: 350px;
+    min-height: 600px;
     border: 1px solid #e1e5e9;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: column;
 }
 
 .bugboard-column-header {
@@ -81,8 +118,11 @@
 .bugboard-tasks {
     padding: 15px;
     min-height: 200px;
-    max-height: 600px;
+    flex: 1;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .bugboard-task {
@@ -90,10 +130,11 @@
     border: 1px solid #e1e5e9;
     border-radius: 6px;
     padding: 12px;
-    margin-bottom: 10px;
+    margin-bottom: 0;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
     cursor: move;
     transition: all 0.2s ease;
+    flex-shrink: 0;
 }
 
 .bugboard-task:hover {
@@ -198,6 +239,29 @@
     font-size: 10px;
 }
 
+/* ===== MENSAJES DE COLUMNAS VACÍAS ===== */
+
+.empty-column-message {
+    text-align: center;
+    padding: 40px 20px;
+    color: #999;
+    border: 2px dashed #e1e5e9;
+    border-radius: 8px;
+    margin: 20px 0;
+    background: #fafafa;
+}
+
+.empty-column-message p {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.empty-column-message small {
+    font-size: 12px;
+    opacity: 0.7;
+}
+
 .add-task-btn {
     width: 100%;
     padding: 10px;
@@ -218,6 +282,60 @@
 .drop-zone-active {
     background: #e3f2fd;
     border: 2px dashed #2196f3;
+}
+
+/* ===== ANIMACIONES OPTIMIZADAS ===== */
+
+.task-moving {
+    animation: taskMove 0.3s ease-in-out;
+    transform: scale(1.02);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    z-index: 10;
+}
+
+.task-deleting {
+    animation: taskDelete 0.3s ease-in-out;
+    opacity: 0.5;
+}
+
+.task-new {
+    animation: taskNew 0.5s ease-in-out;
+    border: 2px solid #4caf50;
+    box-shadow: 0 0 10px rgba(76, 175, 80, 0.3);
+}
+
+@keyframes taskMove {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.02);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+@keyframes taskDelete {
+    0% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(0.8);
+        opacity: 0;
+    }
+}
+
+@keyframes taskNew {
+    0% {
+        transform: translateY(-10px);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0);
+        opacity: 1;
+    }
 }
 
 /* ===== MODAL ===== */
@@ -284,6 +402,15 @@
     min-height: 80px;
 }
 
+.form-row {
+    display: flex;
+    gap: 15px;
+}
+
+.form-row .form-group {
+    flex: 1;
+}
+
 .form-actions {
     display: flex;
     gap: 10px;
@@ -329,5 +456,165 @@
     .bugboard-modal-content {
         width: 95%;
         margin: 10% auto;
+    }
+} 
+
+/* ===== ESTADÍSTICAS DEL USUARIO ===== */
+
+.bugboard-stats-section {
+    margin-bottom: 40px;
+}
+
+.bugboard-stats-section h3 {
+    color: #23282d;
+    border-bottom: 2px solid #0073aa;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+    font-size: 18px;
+}
+
+.bugboard-user-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 15px;
+    margin: 20px 0;
+}
+
+.user-stat-card {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border: 1px solid #e1e5e9;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    transition: all 0.2s ease;
+}
+
+.user-stat-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.stat-icon {
+    font-size: 24px;
+    width: 50px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: #f8f9fa;
+}
+
+.user-stat-card.pending .stat-icon {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.user-stat-card.in-progress .stat-icon {
+    background: #cce5ff;
+    color: #004085;
+}
+
+.user-stat-card.completed .stat-icon {
+    background: #d4edda;
+    color: #155724;
+}
+
+.user-stat-card.urgent .stat-icon {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.stat-content h4 {
+    margin: 0 0 5px 0;
+    color: #23282d;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.stat-content .stat-number {
+    font-size: 24px;
+    font-weight: bold;
+    color: #0073aa;
+}
+
+.user-stat-card.pending .stat-content .stat-number {
+    color: #856404;
+}
+
+.user-stat-card.in-progress .stat-content .stat-number {
+    color: #004085;
+}
+
+.user-stat-card.completed .stat-content .stat-number {
+    color: #155724;
+}
+
+.user-stat-card.urgent .stat-content .stat-number {
+    color: #721c24;
+}
+
+/* ===== BARRA DE PROGRESO ===== */
+
+.user-progress {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border: 1px solid #e1e5e9;
+    margin-top: 20px;
+}
+
+.user-progress h4 {
+    margin: 0 0 15px 0;
+    color: #23282d;
+    font-size: 16px;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 20px;
+    background: #f0f0f0;
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 10px;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #0073aa, #005a87);
+    border-radius: 10px;
+    transition: width 0.3s ease;
+}
+
+.progress-text {
+    font-size: 14px;
+    color: #666;
+    font-weight: 600;
+}
+
+/* ===== RESPONSIVE PARA ESTADÍSTICAS ===== */
+
+@media (max-width: 768px) {
+    .bugboard-user-stats {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 10px;
+    }
+    
+    .user-stat-card {
+        padding: 15px;
+    }
+    
+    .stat-icon {
+        width: 40px;
+        height: 40px;
+        font-size: 20px;
+    }
+    
+    .stat-content .stat-number {
+        font-size: 20px;
     }
 } 

--- a/bugboard/assets/css/notifications.css
+++ b/bugboard/assets/css/notifications.css
@@ -1,0 +1,276 @@
+/* ===== NOTIFICACIONES BUGBOARD ===== */
+
+/* Notificación flotante */
+.bugboard-notice {
+    border-left-color: #0073aa !important;
+    background: #f0f8ff;
+}
+
+.bugboard-notice p {
+    margin: 0;
+    font-size: 14px;
+}
+
+.bugboard-notice a {
+    color: #0073aa;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.bugboard-notice a:hover {
+    text-decoration: underline;
+}
+
+/* ===== WIDGET DEL DASHBOARD ===== */
+
+.bugboard-dashboard-widget {
+    padding: 0;
+}
+
+/* Estadísticas rápidas */
+.bugboard-stats-overview {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin-bottom: 20px;
+    padding: 15px;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+.stat-item {
+    text-align: center;
+    padding: 10px;
+    background: #fff;
+    border-radius: 6px;
+    border: 1px solid #e1e5e9;
+}
+
+.stat-number {
+    display: block;
+    font-size: 24px;
+    font-weight: bold;
+    color: #0073aa;
+    line-height: 1;
+}
+
+.stat-label {
+    display: block;
+    font-size: 12px;
+    color: #666;
+    margin-top: 5px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+/* Lista de tareas recientes */
+.bugboard-recent-tasks {
+    margin-bottom: 20px;
+}
+
+.bugboard-recent-tasks h4 {
+    margin: 0 0 15px 0;
+    font-size: 16px;
+    color: #23282d;
+    border-bottom: 2px solid #0073aa;
+    padding-bottom: 8px;
+}
+
+.bugboard-task-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.bugboard-task-item {
+    padding: 12px;
+    margin-bottom: 8px;
+    background: #fff;
+    border: 1px solid #e1e5e9;
+    border-radius: 6px;
+    border-left: 4px solid #0073aa;
+    transition: all 0.2s ease;
+}
+
+.bugboard-task-item:hover {
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    transform: translateY(-1px);
+}
+
+.bugboard-task-item.priority-alta {
+    border-left-color: #c62828;
+}
+
+.bugboard-task-item.priority-media {
+    border-left-color: #ef6c00;
+}
+
+.bugboard-task-item.priority-baja {
+    border-left-color: #2e7d32;
+}
+
+.task-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 8px;
+}
+
+.task-info strong {
+    font-size: 14px;
+    color: #23282d;
+    flex: 1;
+    margin-right: 10px;
+}
+
+.task-status {
+    font-size: 11px;
+    color: #666;
+    background: #f0f0f0;
+    padding: 2px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.task-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 11px;
+    color: #888;
+}
+
+.task-priority {
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+}
+
+.priority-alta .task-priority {
+    background: #ffebee;
+    color: #c62828;
+}
+
+.priority-media .task-priority {
+    background: #fff3e0;
+    color: #ef6c00;
+}
+
+.priority-baja .task-priority {
+    background: #e8f5e8;
+    color: #2e7d32;
+}
+
+.task-date {
+    font-size: 10px;
+    color: #999;
+}
+
+/* Enlaces rápidos */
+.bugboard-quick-links {
+    display: flex;
+    gap: 10px;
+    padding-top: 15px;
+    border-top: 1px solid #e1e5e9;
+}
+
+.bugboard-quick-links .button {
+    flex: 1;
+    text-align: center;
+    padding: 8px 12px;
+    font-size: 13px;
+}
+
+/* ===== RESPONSIVE ===== */
+
+@media (max-width: 768px) {
+    .bugboard-stats-overview {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px;
+    }
+    
+    .stat-number {
+        font-size: 20px;
+    }
+    
+    .stat-label {
+        font-size: 11px;
+    }
+    
+    .bugboard-quick-links {
+        flex-direction: column;
+    }
+    
+    .bugboard-quick-links .button {
+        margin-bottom: 5px;
+    }
+}
+
+/* ===== ANIMACIONES ===== */
+
+@keyframes bugboardFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.bugboard-notice {
+    animation: bugboardFadeIn 0.3s ease-out;
+}
+
+.bugboard-task-item {
+    animation: bugboardFadeIn 0.2s ease-out;
+}
+
+/* ===== ESTADOS ESPECIALES ===== */
+
+.bugboard-task-item.urgent {
+    border-left-color: #f44336;
+    background: #fff5f5;
+}
+
+.bugboard-task-item.overdue {
+    border-left-color: #ff9800;
+    background: #fff8e1;
+}
+
+/* ===== TOOLTIPS ===== */
+
+.bugboard-task-item {
+    position: relative;
+}
+
+.bugboard-task-item:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 5px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    white-space: nowrap;
+    z-index: 1000;
+    margin-bottom: 5px;
+}
+
+.bugboard-task-item:hover::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: #333;
+    z-index: 1000;
+    margin-bottom: 1px;
+} 

--- a/bugboard/assets/js/tablero.js
+++ b/bugboard/assets/js/tablero.js
@@ -7,6 +7,8 @@ jQuery(document).ready(function($) {
     // Variables globales
     var currentTask = null;
     var isDragging = false;
+    var bugboardAjaxUrl = bugboardAjax.ajaxurl;
+    var bugboardNonce = bugboardAjax.nonce;
     
     // Inicializar el tablero
     initTablero();
@@ -100,7 +102,10 @@ jQuery(document).ready(function($) {
     function setupDragAndDrop() {
         // Hacer las tareas arrastrables
         $(document).on('mousedown', '.bugboard-task', function(e) {
-            if (e.target.classList.contains('task-actions')) return;
+            // No activar drag si se hace clic en botones de acción
+            if ($(e.target).closest('.task-actions').length > 0) {
+                return;
+            }
             
             currentTask = $(this);
             isDragging = true;
@@ -152,14 +157,51 @@ jQuery(document).ready(function($) {
      * Manejar soltar el mouse
      */
     function handleMouseUp(e) {
-        if (!isDragging || !currentTask) return;
+        console.log('handleMouseUp llamado');
+        console.log('isDragging:', isDragging);
+        console.log('currentTask:', currentTask);
+        console.log('target:', e.target);
+        
+        if (!isDragging || !currentTask) {
+            console.log('No se procesa - no está arrastrando o no hay tarea actual');
+            return;
+        }
+        
+        // Verificar que no se hizo clic en un botón de acción
+        if ($(e.target).closest('.task-actions').length > 0) {
+            console.log('Clic en botón de acción - no procesar drop');
+            // Si se hizo clic en un botón de acción, no procesar el drop
+            $('.task-ghost').remove();
+            currentTask.removeClass('task-dragging');
+            currentTask = null;
+            isDragging = false;
+            
+            $(document).off('mousemove', handleMouseMove);
+            $(document).off('mouseup', handleMouseUp);
+            return;
+        }
         
         var targetColumn = $(e.target).closest('.bugboard-tasks');
+        console.log('targetColumn encontrado:', targetColumn.length > 0);
+        
         if (targetColumn.length > 0) {
             var newStatus = targetColumn.closest('.bugboard-column').data('status');
             var taskId = currentTask.data('task-id');
+            var oldStatus = currentTask.data('status');
             
-            updateTaskStatus(taskId, newStatus);
+            // Verificar si hay elementos duplicados antes de procesar
+            var allElementsWithId = $('.bugboard-task[data-task-id="' + taskId + '"]');
+            if (allElementsWithId.length > 1) {
+                console.log('¡ADVERTENCIA! Se encontraron elementos duplicados antes del drop. Limpiando...');
+                allElementsWithId.not(':first').remove();
+                currentTask = $('.bugboard-task[data-task-id="' + taskId + '"]').first();
+            }
+            
+            // Solo actualizar si el estado cambió
+            if (oldStatus !== newStatus) {
+                console.log('Llamando updateTaskStatus con:', { taskId: taskId, newStatus: newStatus });
+                updateTaskStatus(taskId, newStatus);
+            }
         }
         
         // Limpiar
@@ -224,6 +266,13 @@ jQuery(document).ready(function($) {
         // Limpiar todas las columnas
         $('.bugboard-tasks').empty();
         
+        // Verificar que no haya elementos duplicados antes de renderizar
+        var existingTasks = $('.bugboard-task');
+        if (existingTasks.length > 0) {
+            console.log('¡ADVERTENCIA! Se encontraron elementos de tarea antes de renderizar. Limpiando...');
+            existingTasks.remove();
+        }
+        
         // Agrupar tareas por estado
         var tasksByStatus = {};
         tasks.forEach(function(task) {
@@ -260,15 +309,22 @@ jQuery(document).ready(function($) {
      */
     function createTaskElement(task) {
         var priorityClass = 'priority-' + task.priority;
-        var assigneeName = task.assignee ? getUserName(task.assignee) : 'Sin asignar';
+        var assigneeName = task.assignee_name || 'Sin asignar';
+        
+        // Formatear fecha
+        var taskDate = '';
+        if (task.created_at) {
+            var date = new Date(task.created_at);
+            taskDate = date.toLocaleDateString('es-ES');
+        }
         
         var taskHtml = `
             <div class="bugboard-task ${priorityClass}" data-task-id="${task.id}" data-status="${task.status}">
                 <div class="task-header">
                     <h4 class="task-title">${task.title}</h4>
                     <div class="task-actions">
-                        <button class="edit-task-btn" onclick="editTask(${task.id})">✏️</button>
-                        <button class="delete-task-btn" onclick="deleteTask(${task.id})">🗑️</button>
+                        <button class="edit-task-btn" onclick="editTask(${task.id}); event.stopPropagation();">✏️</button>
+                        <button class="delete-task-btn" onclick="deleteTask(${task.id}); event.stopPropagation();">🗑️</button>
                     </div>
                 </div>
                 <div class="task-content">
@@ -277,7 +333,7 @@ jQuery(document).ready(function($) {
                 <div class="task-footer">
                     <span class="task-priority ${priorityClass}">${task.priority}</span>
                     <span class="task-assignee">👤 ${assigneeName}</span>
-                    <span class="task-date">📅 ${task.date}</span>
+                    <span class="task-date">📅 ${taskDate}</span>
                 </div>
             </div>
         `;
@@ -286,7 +342,7 @@ jQuery(document).ready(function($) {
     }
     
     /**
-     * Obtener nombre de usuario
+     * Obtener nombre de usuario (mantenido para compatibilidad)
      */
     function getUserName(userId) {
         if (!userId || userId === '') {
@@ -313,46 +369,60 @@ jQuery(document).ready(function($) {
         $('#task-description').val('');
         $('#task-priority').val('media');
         $('#task-assignee').val('');
+        $('#task-due-date').val('');
+        $('#task-estimated-hours').val('');
         $('#modal-title').text('Añadir Nueva Tarea');
         
-        $('#task-modal').show();
+        $('.bugboard-modal').show();
     }
     
     /**
      * Cerrar modal
      */
     function closeTaskModal() {
-        $('#task-modal').hide();
+        $('.bugboard-modal').hide();
     }
     
     /**
-     * Guardar tarea
+     * Guardar tarea (Optimizado)
      */
     function saveTask() {
         var formData = {
             task_id: $('#task-id').val(),
-            task_title: $('#task-title').val(),
-            task_description: $('#task-description').val(),
-            task_status: $('#task-status').val(),
-            task_priority: $('#task-priority').val(),
-            task_assignee: $('#task-assignee').val()
+            title: $('#task-title').val(),
+            description: $('#task-description').val(),
+            status: $('#task-status').val(),
+            priority: $('#task-priority').val(),
+            assignee: $('#task-assignee').val(),
+            due_date: $('#task-due-date').val(),
+            estimated_hours: $('#task-estimated-hours').val()
         };
         
         console.log('Guardando tarea:', formData);
+        
+        // Cerrar modal inmediatamente para mejor UX
+        closeTaskModal();
+        
+        var action = formData.task_id ? 'bugboard_update_task' : 'bugboard_create_task';
         
         $.ajax({
             url: bugboardAjaxUrl,
             type: 'POST',
             data: {
-                action: 'bugboard_save_task',
+                action: action,
                 nonce: bugboardNonce,
                 ...formData
             },
             success: function(response) {
                 console.log('Respuesta de guardar:', response);
                 if (response.success) {
-                    closeTaskModal();
-                    loadTasks();
+                    // Si es una tarea nueva, añadirla inmediatamente
+                    if (!formData.task_id) {
+                        addTaskToColumn(response.data.task.id, response.data.task);
+                    } else {
+                        // Si es edición, actualizar la tarea existente
+                        updateTaskInColumn(response.data.task.id, response.data.task);
+                    }
                     showNotification('Tarea guardada correctamente', 'success');
                 } else {
                     showNotification('Error al guardar la tarea: ' + (response.data ? response.data.message : 'Error desconocido'), 'error');
@@ -367,9 +437,53 @@ jQuery(document).ready(function($) {
     }
     
     /**
-     * Actualizar estado de tarea
+     * Actualizar estado de tarea (Optimizado)
      */
     function updateTaskStatus(taskId, newStatus) {
+        console.log('updateTaskStatus llamado con:', { taskId: taskId, newStatus: newStatus });
+        
+        // Actualización optimista - cambiar inmediatamente en la UI
+        var taskElement = $('.bugboard-task[data-task-id="' + taskId + '"]');
+        var oldStatus = taskElement.data('status');
+        
+        console.log('Elemento encontrado:', taskElement.length);
+        console.log('Estado anterior:', oldStatus);
+        console.log('Estado nuevo:', newStatus);
+        
+        // Si ya está en el estado correcto, no hacer nada
+        if (oldStatus === newStatus) {
+            console.log('Ya está en el estado correcto, no hacer nada');
+            return;
+        }
+        
+        // Verificar si hay elementos duplicados
+        var allElementsWithId = $('.bugboard-task[data-task-id="' + taskId + '"]');
+        console.log('Elementos con el mismo ID encontrados:', allElementsWithId.length);
+        
+        if (allElementsWithId.length > 1) {
+            console.log('¡ADVERTENCIA! Se encontraron elementos duplicados. Removiendo duplicados...');
+            // Mantener solo el primer elemento y remover los demás
+            allElementsWithId.not(':first').remove();
+            taskElement = $('.bugboard-task[data-task-id="' + taskId + '"]').first();
+        }
+        
+        // Mover la tarea visualmente inmediatamente
+        var targetColumn = $('.bugboard-column[data-status="' + newStatus + '"] .bugboard-tasks');
+        console.log('Columna objetivo encontrada:', targetColumn.length);
+        
+        // Mover el elemento original, no crear un clon
+        taskElement.addClass('task-moving');
+        targetColumn.append(taskElement);
+        
+        // Actualizar el estado del elemento
+        taskElement.data('status', newStatus);
+        
+        console.log('Tarea movida visualmente');
+        
+        // Actualizar contadores inmediatamente
+        updateColumnCounts();
+        
+        // Hacer la petición AJAX en background
         $.ajax({
             url: bugboardAjaxUrl,
             type: 'POST',
@@ -380,17 +494,94 @@ jQuery(document).ready(function($) {
                 status: newStatus
             },
             success: function(response) {
+                console.log('Respuesta de updateTaskStatus:', response);
                 if (response.success) {
-                    loadTasks();
+                    // Remover clase de animación
+                    taskElement.removeClass('task-moving');
                     showNotification('Estado actualizado correctamente', 'success');
                 } else {
+                    // Revertir cambios si falló
+                    taskElement.removeClass('task-moving');
+                    // Mover de vuelta a la columna original
+                    var originalColumn = $('.bugboard-column[data-status="' + oldStatus + '"] .bugboard-tasks');
+                    originalColumn.append(taskElement);
+                    taskElement.data('status', oldStatus);
+                    updateColumnCounts();
                     showNotification('Error al actualizar el estado', 'error');
                 }
             },
-            error: function() {
+            error: function(xhr, status, error) {
+                console.error('Error en updateTaskStatus:', error);
+                // Revertir cambios si falló
+                taskElement.removeClass('task-moving');
+                // Mover de vuelta a la columna original
+                var originalColumn = $('.bugboard-column[data-status="' + oldStatus + '"] .bugboard-tasks');
+                originalColumn.append(taskElement);
+                taskElement.data('status', oldStatus);
+                updateColumnCounts();
                 showNotification('Error al actualizar el estado', 'error');
             }
         });
+    }
+    
+    /**
+     * Actualizar contadores de columnas
+     */
+    function updateColumnCounts() {
+        $('.bugboard-column').each(function() {
+            var column = $(this);
+            var status = column.data('status');
+            var taskCount = column.find('.bugboard-task').length;
+            var emptyMessage = column.find('.empty-column-message');
+            
+            column.find('.task-count').text(taskCount);
+            
+            // Mostrar/ocultar mensaje de columna vacía
+            if (taskCount === 0) {
+                emptyMessage.show();
+            } else {
+                emptyMessage.hide();
+            }
+            
+            console.log('Columna ' + status + ': ' + taskCount + ' tareas');
+        });
+    }
+    
+    /**
+     * Añadir tarea a una columna
+     */
+    function addTaskToColumn(taskId, taskData) {
+        var targetColumn = $('.bugboard-column[data-status="' + taskData.status + '"] .bugboard-tasks');
+        var taskElement = createTaskElement(taskData);
+        
+        taskElement.addClass('task-new');
+        targetColumn.append(taskElement);
+        updateColumnCounts();
+        
+        // Remover clase de animación después de un tiempo
+        setTimeout(function() {
+            taskElement.removeClass('task-new');
+        }, 2000);
+    }
+    
+    /**
+     * Actualizar tarea en una columna
+     */
+    function updateTaskInColumn(taskId, taskData) {
+        var taskElement = $('.bugboard-task[data-task-id="' + taskId + '"]');
+        if (taskElement.length > 0) {
+            // Actualizar contenido de la tarea
+            taskElement.find('.task-title').text(taskData.title);
+            taskElement.find('.task-description').text(taskData.description || 'Sin descripción');
+            taskElement.find('.task-priority').text(taskData.priority);
+            taskElement.find('.task-priority').removeClass().addClass('task-priority priority-' + taskData.priority);
+            
+            // Si cambió el estado, mover la tarea
+            var currentStatus = taskElement.data('status');
+            if (currentStatus !== taskData.status) {
+                updateTaskStatus(taskId, taskData.status);
+            }
+        }
     }
     
     /**
@@ -410,8 +601,6 @@ jQuery(document).ready(function($) {
     // Funciones globales para botones
     window.editTask = function(taskId) {
         console.log('Editando tarea:', taskId);
-        console.log('URL:', bugboardAjaxUrl);
-        console.log('Nonce:', bugboardNonce);
         
         var requestData = {
             action: 'bugboard_get_task',
@@ -438,13 +627,15 @@ jQuery(document).ready(function($) {
                     $('#task-description').val(task.description);
                     $('#task-status').val(task.status);
                     $('#task-priority').val(task.priority);
-                    $('#task-assignee').val(task.assignee);
+                    $('#task-assignee').val(task.assignee_id || '');
+                    $('#task-due-date').val(task.due_date || '');
+                    $('#task-estimated-hours').val(task.estimated_hours || '');
                     
                     // Cambiar título del modal
                     $('#modal-title').text('Editar Tarea');
                     
                     // Mostrar modal
-                    $('#task-modal').show();
+                    $('.bugboard-modal').show();
                     
                     console.log('Modal llenado y mostrado');
                 } else {
@@ -454,9 +645,6 @@ jQuery(document).ready(function($) {
             },
             error: function(xhr, status, error) {
                 console.error('Error AJAX al cargar tarea:', error);
-                console.error('Status:', status);
-                console.error('XHR:', xhr);
-                console.error('Response Text:', xhr.responseText);
                 showNotification('Error al cargar la tarea: ' + error, 'error');
             }
         });
@@ -465,6 +653,10 @@ jQuery(document).ready(function($) {
     window.deleteTask = function(taskId) {
         if (confirm('¿Estás seguro de que quieres eliminar esta tarea?')) {
             console.log('Eliminando tarea:', taskId);
+            
+            // Eliminación optimista - quitar inmediatamente de la UI
+            var taskElement = $('.bugboard-task[data-task-id="' + taskId + '"]');
+            taskElement.addClass('task-deleting');
             
             $.ajax({
                 url: bugboardAjaxUrl,
@@ -476,18 +668,27 @@ jQuery(document).ready(function($) {
                 },
                 success: function(response) {
                     if (response.success) {
+                        taskElement.fadeOut(300, function() {
+                            $(this).remove();
+                            updateColumnCounts();
+                        });
                         showNotification('Tarea eliminada correctamente', 'success');
-                        loadTasks(); // Recargar tareas
                     } else {
+                        taskElement.removeClass('task-deleting');
                         showNotification('Error al eliminar la tarea', 'error');
                     }
                 },
                 error: function(xhr, status, error) {
                     console.error('Error al eliminar tarea:', error);
+                    taskElement.removeClass('task-deleting');
                     showNotification('Error al eliminar la tarea', 'error');
                 }
             });
         }
+    };
+    
+    window.openTaskModal = function(status) {
+        openTaskModal(status);
     };
     
     window.closeTaskModal = function() {

--- a/bugboard/bugboard.php
+++ b/bugboard/bugboard.php
@@ -1,12 +1,18 @@
 <?php
 /**
  * Plugin Name: BugBoard
- * Plugin URI: 
- * Description: Plugin para gestión de tareas y bugs
+ * Plugin URI: https://github.com/tu-usuario/bugboard
+ * Description: Un tablero Kanban para gestión de tareas y bugs en WordPress
  * Version: 1.0.0
- * Author: 
+ * Author: Tu Nombre
+ * Author URI: https://tu-sitio.com
  * License: GPL v2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: bugboard
+ * Domain Path: /languages
+ * Requires at least: 5.0
+ * Tested up to: 6.4
+ * Requires PHP: 7.4
  */
 
 // Prevenir acceso directo
@@ -14,246 +20,76 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Definir constantes del plugin
+define('BUGBOARD_VERSION', '1.0.0');
+define('BUGBOARD_PLUGIN_URL', plugin_dir_url(__FILE__));
+define('BUGBOARD_PLUGIN_PATH', plugin_dir_path(__FILE__));
+
 /**
  * Clase principal del plugin BugBoard
  */
 class BugBoard {
-    
+
     /**
-     * Constructor de la clase
+     * Constructor
      */
     public function __construct() {
-        // Hooks para inicializar el plugin
-        add_action('init', array($this, 'init'));
-        add_action('admin_menu', array($this, 'add_admin_menu'));
-        add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
-        
-        // Hooks AJAX
-        add_action('wp_ajax_bugboard_save_task', array($this, 'save_task_ajax'));
-        
-        // Registrar hooks AJAX del tablero
-        add_action('init', array($this, 'register_tablero_ajax_hooks'));
+        $this->init_hooks();
+        $this->load_dependencies();
     }
-    
+
     /**
-     * Inicialización del plugin
+     * Inicializar hooks
+     */
+    private function init_hooks() {
+        // Hook de activación
+        register_activation_hook(__FILE__, array('BugBoard_Activator', 'activate'));
+        
+        // Hook de desactivación
+        register_deactivation_hook(__FILE__, array($this, 'deactivate'));
+        
+        // Hook de desinstalación
+        register_uninstall_hook(__FILE__, array('BugBoard_Activator', 'uninstall'));
+        
+        // Inicializar plugin
+        add_action('plugins_loaded', array($this, 'init'));
+    }
+
+    /**
+     * Cargar dependencias
+     */
+    private function load_dependencies() {
+        // Incluir archivos necesarios
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-activator.php';
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-tasks.php';
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-ajax.php';
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-admin.php';
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-tablero.php';
+        require_once BUGBOARD_PLUGIN_PATH . 'includes/class-bugboard-notifications.php';
+    }
+
+    /**
+     * Inicializar el plugin
      */
     public function init() {
-        // Registrar el Custom Post Type
-        $this->register_bug_post_type();
+        // Inicializar clases
+        new BugBoard_Admin();
+        new BugBoard_Ajax();
+        new BugBoard_Tablero();
+        new BugBoard_Notifications();
+        
+        // Cargar traducciones
+        load_plugin_textdomain('bugboard', false, dirname(plugin_basename(__FILE__)) . '/languages');
     }
-    
+
     /**
-     * Registrar hooks AJAX del tablero
+     * Desactivar el plugin
      */
-    public function register_tablero_ajax_hooks() {
-        // Cargar la clase del tablero
-        require_once plugin_dir_path(__FILE__) . 'includes/class-bugboard-tablero.php';
-        
-        // Crear instancia y registrar hooks
-        $tablero = new BugBoard_Tablero();
-        $tablero->register_ajax_hooks();
-        
-        error_log('BugBoard: Hooks AJAX del tablero registrados');
-    }
-    
-    /**
-     * Registrar el Custom Post Type 'bug'
-     */
-    public function register_bug_post_type() {
-        $labels = array(
-            'name'                  => 'Tareas',
-            'singular_name'         => 'Tarea',
-            'menu_name'             => 'Tareas',
-            'name_admin_bar'        => 'Tarea',
-            'add_new'               => 'Añadir Nueva',
-            'add_new_item'          => 'Añadir Nueva Tarea',
-            'new_item'              => 'Nueva Tarea',
-            'edit_item'             => 'Editar Tarea',
-            'view_item'             => 'Ver Tarea',
-            'all_items'             => 'Todas las Tareas',
-            'search_items'          => 'Buscar Tareas',
-            'parent_item_colon'     => 'Tareas Padre:',
-            'not_found'             => 'No se encontraron tareas.',
-            'not_found_in_trash'    => 'No se encontraron tareas en la papelera.',
-            'featured_image'        => 'Imagen Destacada de la Tarea',
-            'set_featured_image'    => 'Establecer imagen destacada',
-            'remove_featured_image' => 'Eliminar imagen destacada',
-            'use_featured_image'    => 'Usar como imagen destacada',
-            'archives'              => 'Archivo de Tareas',
-            'insert_into_item'      => 'Insertar en la tarea',
-            'uploaded_to_this_item' => 'Subido a esta tarea',
-            'filter_items_list'     => 'Filtrar lista de tareas',
-            'items_list_navigation' => 'Navegación de lista de tareas',
-            'items_list'            => 'Lista de tareas',
-        );
-        
-        $args = array(
-            'labels'              => $labels,
-            'public'              => false, // Solo visible en admin
-            'publicly_queryable'  => false,
-            'show_ui'             => true,
-            'show_in_menu'        => true,
-            'query_var'           => true,
-            'rewrite'             => array('slug' => 'bug'),
-            'capability_type'     => 'post',
-            'has_archive'         => false,
-            'hierarchical'        => false,
-            'menu_position'       => null,
-            'menu_icon'           => 'dashicons-bug',
-            'supports'            => array('title', 'editor', 'author'),
-            'show_in_rest'        => false, // Sin opción de exportación
-        );
-        
-        register_post_type('bug', $args);
-    }
-    
-    /**
-     * Añadir menú en el admin
-     */
-    public function add_admin_menu() {
-        // Menú principal BugBoard
-        add_menu_page(
-            'BugBoard', // Título de la página
-            'BugBoard', // Título del menú
-            'manage_options', // Capacidad requerida
-            'bugboard', // Slug del menú
-            array($this, 'bugboard_main_page'), // Función callback
-            'dashicons-bug', // Icono
-            30 // Posición en el menú
-        );
-        
-        // Submenú Tablero
-        add_submenu_page(
-            'bugboard', // Parent slug
-            'Tablero', // Título de la página
-            'Tablero', // Título del submenú
-            'manage_options', // Capacidad requerida
-            'bugboard-tablero', // Slug del submenú
-            array($this, 'bugboard_tablero_page') // Función callback
-        );
-    }
-    
-    /**
-     * Página principal de BugBoard
-     */
-    public function bugboard_main_page() {
-        ?>
-        <div class="wrap">
-            <h1>BugBoard</h1>
-            <p>Bienvenido al plugin BugBoard para gestión de tareas.</p>
-        </div>
-        <?php
-    }
-    
-    /**
-     * Página del tablero
-     */
-    public function bugboard_tablero_page() {
-        // Cargar la clase del tablero
-        require_once plugin_dir_path(__FILE__) . 'includes/class-bugboard-tablero.php';
-        
-        // Inicializar el tablero
-        $tablero = new BugBoard_Tablero();
-        
-        // Renderizar el tablero
-        $tablero->render_tablero();
-    }
-    
-    /**
-     * Cargar scripts y estilos del admin
-     */
-    public function enqueue_admin_scripts($hook) {
-        // Debug: mostrar el hook actual
-        error_log('BugBoard Hook: ' . $hook);
-        
-        // Solo cargar en páginas de BugBoard
-        if (strpos($hook, 'bugboard') !== false) {
-            wp_enqueue_style(
-                'bugboard-admin-style',
-                plugin_dir_url(__FILE__) . 'assets/css/admin.css',
-                array(),
-                '1.0.0'
-            );
-            
-            // Cargar JavaScript solo en la página del tablero
-            if (strpos($hook, 'bugboard-tablero') !== false || $hook === 'bugboard_page_bugboard-tablero') {
-                wp_enqueue_script(
-                    'bugboard-tablero-js',
-                    plugin_dir_url(__FILE__) . 'assets/js/tablero.js',
-                    array('jquery'),
-                    '1.0.0',
-                    true
-                );
-                
-                // Debug: confirmar que se está cargando el script
-                error_log('BugBoard: Cargando script del tablero');
-            }
-        }
-    }
-    
-    /**
-     * Guardar tarea via AJAX
-     */
-    public function save_task_ajax() {
-        check_ajax_referer('bugboard_nonce', 'nonce');
-        
-        $task_data = array(
-            'task_id' => isset($_POST['task_id']) ? intval($_POST['task_id']) : 0,
-            'task_title' => sanitize_text_field($_POST['task_title']),
-            'task_description' => wp_kses_post($_POST['task_description']),
-            'task_status' => sanitize_text_field($_POST['task_status']),
-            'task_priority' => sanitize_text_field($_POST['task_priority']),
-            'task_assignee' => sanitize_text_field($_POST['task_assignee'])
-        );
-        
-        // Cargar la clase del tablero
-        require_once plugin_dir_path(__FILE__) . 'includes/class-bugboard-tablero.php';
-        $tablero = new BugBoard_Tablero();
-        
-        $result = $tablero->save_task($task_data);
-        
-        if ($result) {
-            wp_send_json_success(array(
-                'message' => 'Tarea guardada correctamente',
-                'task_id' => $result
-            ));
-        } else {
-            wp_send_json_error(array('message' => 'Error al guardar la tarea'));
-        }
+    public function deactivate() {
+        // Limpiar opciones temporales si es necesario
+        // delete_option('bugboard_temp_option');
     }
 }
 
-/**
- * Inicializar el plugin
- */
-function bugboard_init() {
-    new BugBoard();
-}
-
-// Hook para inicializar el plugin
-add_action('plugins_loaded', 'bugboard_init');
-
-/**
- * Activación del plugin
- */
-function bugboard_activate() {
-    // Registrar el CPT al activar
-    $bugboard = new BugBoard();
-    $bugboard->register_bug_post_type();
-    
-    // Flush rewrite rules
-    flush_rewrite_rules();
-}
-
-/**
- * Desactivación del plugin
- */
-function bugboard_deactivate() {
-    // Flush rewrite rules
-    flush_rewrite_rules();
-}
-
-// Hooks de activación y desactivación
-register_activation_hook(__FILE__, 'bugboard_activate');
-register_deactivation_hook(__FILE__, 'bugboard_deactivate'); 
+// Inicializar el plugin
+new BugBoard(); 

--- a/bugboard/includes/class-bugboard-activator.php
+++ b/bugboard/includes/class-bugboard-activator.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Clase para manejar la activación del plugin
+ */
+class BugBoard_Activator {
+
+    /**
+     * Crear tablas personalizadas al activar el plugin
+     */
+    public static function activate() {
+        self::create_tables();
+        self::insert_default_data();
+    }
+
+    /**
+     * Crear las tablas personalizadas
+     */
+    private static function create_tables() {
+        global $wpdb;
+        
+        $charset_collate = $wpdb->get_charset_collate();
+        
+        // Tabla principal de tareas
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        $sql_tasks = "CREATE TABLE $table_tasks (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            title varchar(255) NOT NULL,
+            description text,
+            status varchar(50) NOT NULL DEFAULT 'por-hacer',
+            priority varchar(20) NOT NULL DEFAULT 'media',
+            assignee_id bigint(20) UNSIGNED,
+            author_id bigint(20) UNSIGNED NOT NULL,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            due_date datetime NULL,
+            estimated_hours decimal(5,2) NULL,
+            PRIMARY KEY (id),
+            KEY status (status),
+            KEY priority (priority),
+            KEY assignee_id (assignee_id),
+            KEY author_id (author_id),
+            FOREIGN KEY (assignee_id) REFERENCES {$wpdb->users}(ID) ON DELETE SET NULL,
+            FOREIGN KEY (author_id) REFERENCES {$wpdb->users}(ID) ON DELETE CASCADE
+        ) $charset_collate;";
+
+        // Tabla de comentarios
+        $table_comments = $wpdb->prefix . 'bugboard_comments';
+        $sql_comments = "CREATE TABLE $table_comments (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            task_id mediumint(9) NOT NULL,
+            user_id bigint(20) UNSIGNED NOT NULL,
+            comment text NOT NULL,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY task_id (task_id),
+            KEY user_id (user_id),
+            FOREIGN KEY (task_id) REFERENCES $table_tasks(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES {$wpdb->users}(ID) ON DELETE CASCADE
+        ) $charset_collate;";
+
+        // Tabla de archivos adjuntos
+        $table_attachments = $wpdb->prefix . 'bugboard_attachments';
+        $sql_attachments = "CREATE TABLE $table_attachments (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            task_id mediumint(9) NOT NULL,
+            filename varchar(255) NOT NULL,
+            filepath varchar(500) NOT NULL,
+            filesize bigint(20) UNSIGNED NOT NULL,
+            mime_type varchar(100) NOT NULL,
+            uploaded_at datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY task_id (task_id),
+            FOREIGN KEY (task_id) REFERENCES $table_tasks(id) ON DELETE CASCADE
+        ) $charset_collate;";
+
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        
+        dbDelta($sql_tasks);
+        dbDelta($sql_comments);
+        dbDelta($sql_attachments);
+        
+        // Guardar versión de la base de datos
+        update_option('bugboard_db_version', '1.0.0');
+    }
+
+    /**
+     * Insertar datos por defecto
+     */
+    private static function insert_default_data() {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        $current_user_id = get_current_user_id();
+        
+        // Insertar algunas tareas de ejemplo
+        $sample_tasks = array(
+            array(
+                'title' => 'Configurar el plugin BugBoard',
+                'description' => 'Instalar y configurar todas las funcionalidades del plugin',
+                'status' => 'completado',
+                'priority' => 'alta',
+                'assignee_id' => $current_user_id,
+                'author_id' => $current_user_id
+            ),
+            array(
+                'title' => 'Implementar drag and drop',
+                'description' => 'Agregar funcionalidad de arrastrar y soltar para las tareas',
+                'status' => 'en-progreso',
+                'priority' => 'alta',
+                'assignee_id' => $current_user_id,
+                'author_id' => $current_user_id
+            ),
+            array(
+                'title' => 'Diseñar interfaz de usuario',
+                'description' => 'Crear una interfaz moderna y responsiva',
+                'status' => 'por-hacer',
+                'priority' => 'media',
+                'assignee_id' => $current_user_id,
+                'author_id' => $current_user_id
+            )
+        );
+        
+        foreach ($sample_tasks as $task) {
+            $wpdb->insert(
+                $table_tasks,
+                $task,
+                array('%s', '%s', '%s', '%s', '%d', '%d')
+            );
+        }
+    }
+
+    /**
+     * Desinstalar el plugin
+     */
+    public static function uninstall() {
+        global $wpdb;
+        
+        // Eliminar tablas
+        $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}bugboard_attachments");
+        $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}bugboard_comments");
+        $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}bugboard_tasks");
+        
+        // Eliminar opciones
+        delete_option('bugboard_db_version');
+    }
+} 

--- a/bugboard/includes/class-bugboard-admin.php
+++ b/bugboard/includes/class-bugboard-admin.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Clase para manejar la interfaz de administración
+ */
+class BugBoard_Admin {
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        // Esta clase se encarga principalmente de la interfaz
+        // que ya está manejada por BugBoard_Tablero
+    }
+} 

--- a/bugboard/includes/class-bugboard-ajax.php
+++ b/bugboard/includes/class-bugboard-ajax.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Clase para manejar las peticiones AJAX del BugBoard
+ */
+class BugBoard_Ajax {
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_action('wp_ajax_bugboard_get_tasks', array($this, 'get_tasks'));
+        add_action('wp_ajax_bugboard_get_task', array($this, 'get_task'));
+        add_action('wp_ajax_bugboard_create_task', array($this, 'create_task'));
+        add_action('wp_ajax_bugboard_update_task', array($this, 'update_task'));
+        add_action('wp_ajax_bugboard_delete_task', array($this, 'delete_task'));
+        add_action('wp_ajax_bugboard_update_task_status', array($this, 'update_task_status'));
+        add_action('wp_ajax_bugboard_get_users', array($this, 'get_users'));
+    }
+
+    /**
+     * Obtener todas las tareas
+     */
+    public function get_tasks() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        try {
+            $tasks = BugBoard_Tasks::get_all_tasks();
+            
+            // Formatear tareas para el frontend
+            $formatted_tasks = array();
+            foreach ($tasks as $task) {
+                $formatted_tasks[] = BugBoard_Tasks::format_task_for_frontend($task);
+            }
+            
+            wp_send_json_success($formatted_tasks);
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Obtener una tarea específica
+     */
+    public function get_task() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        $task_id = intval($_POST['task_id']);
+        
+        if (!$task_id) {
+            wp_send_json_error(array('message' => 'ID de tarea inválido'));
+        }
+
+        try {
+            $task = BugBoard_Tasks::get_task($task_id);
+            
+            if (!$task) {
+                wp_send_json_error(array('message' => 'Tarea no encontrada'));
+            }
+            
+            $formatted_task = BugBoard_Tasks::format_task_for_frontend($task);
+            wp_send_json_success($formatted_task);
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Crear una nueva tarea
+     */
+    public function create_task() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        $task_data = array(
+            'title' => sanitize_text_field($_POST['title']),
+            'description' => sanitize_textarea_field($_POST['description']),
+            'status' => sanitize_text_field($_POST['status']),
+            'priority' => sanitize_text_field($_POST['priority']),
+            'assignee_id' => !empty($_POST['assignee']) ? intval($_POST['assignee']) : null,
+            'due_date' => !empty($_POST['due_date']) ? sanitize_text_field($_POST['due_date']) : null,
+            'estimated_hours' => !empty($_POST['estimated_hours']) ? floatval($_POST['estimated_hours']) : null
+        );
+
+        try {
+            $task_id = BugBoard_Tasks::create_task($task_data);
+            
+            if (is_wp_error($task_id)) {
+                wp_send_json_error(array('message' => $task_id->get_error_message()));
+            }
+            
+            // Obtener la tarea creada
+            $task = BugBoard_Tasks::get_task($task_id);
+            $formatted_task = BugBoard_Tasks::format_task_for_frontend($task);
+            
+            wp_send_json_success(array(
+                'message' => 'Tarea creada correctamente',
+                'task' => $formatted_task
+            ));
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Actualizar una tarea
+     */
+    public function update_task() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        $task_id = intval($_POST['task_id']);
+        
+        if (!$task_id) {
+            wp_send_json_error(array('message' => 'ID de tarea inválido'));
+        }
+
+        $task_data = array(
+            'title' => sanitize_text_field($_POST['title']),
+            'description' => sanitize_textarea_field($_POST['description']),
+            'status' => sanitize_text_field($_POST['status']),
+            'priority' => sanitize_text_field($_POST['priority']),
+            'assignee_id' => !empty($_POST['assignee']) ? intval($_POST['assignee']) : null,
+            'due_date' => !empty($_POST['due_date']) ? sanitize_text_field($_POST['due_date']) : null,
+            'estimated_hours' => !empty($_POST['estimated_hours']) ? floatval($_POST['estimated_hours']) : null
+        );
+
+        try {
+            $result = BugBoard_Tasks::update_task($task_id, $task_data);
+            
+            if (is_wp_error($result)) {
+                wp_send_json_error(array('message' => $result->get_error_message()));
+            }
+            
+            // Obtener la tarea actualizada
+            $task = BugBoard_Tasks::get_task($task_id);
+            $formatted_task = BugBoard_Tasks::format_task_for_frontend($task);
+            
+            wp_send_json_success(array(
+                'message' => 'Tarea actualizada correctamente',
+                'task' => $formatted_task
+            ));
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Eliminar una tarea
+     */
+    public function delete_task() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        $task_id = intval($_POST['task_id']);
+        
+        if (!$task_id) {
+            wp_send_json_error(array('message' => 'ID de tarea inválido'));
+        }
+
+        try {
+            $result = BugBoard_Tasks::delete_task($task_id);
+            
+            if (is_wp_error($result)) {
+                wp_send_json_error(array('message' => $result->get_error_message()));
+            }
+            
+            wp_send_json_success(array('message' => 'Tarea eliminada correctamente'));
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Actualizar el estado de una tarea
+     */
+    public function update_task_status() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        $task_id = intval($_POST['task_id']);
+        $new_status = sanitize_text_field($_POST['status']);
+        
+        if (!$task_id) {
+            wp_send_json_error(array('message' => 'ID de tarea inválido'));
+        }
+
+        try {
+            $result = BugBoard_Tasks::update_task_status($task_id, $new_status);
+            
+            if (is_wp_error($result)) {
+                wp_send_json_error(array('message' => $result->get_error_message()));
+            }
+            
+            wp_send_json_success(array('message' => 'Estado actualizado correctamente'));
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+
+    /**
+     * Obtener usuarios disponibles
+     */
+    public function get_users() {
+        // Verificar nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
+            wp_die('Nonce inválido');
+        }
+
+        // Verificar permisos
+        if (!current_user_can('manage_options')) {
+            wp_die('Permisos insuficientes');
+        }
+
+        try {
+            $users = BugBoard_Tasks::get_available_users();
+            wp_send_json_success($users);
+        } catch (Exception $e) {
+            wp_send_json_error(array('message' => $e->getMessage()));
+        }
+    }
+} 

--- a/bugboard/includes/class-bugboard-notifications.php
+++ b/bugboard/includes/class-bugboard-notifications.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Clase para manejar notificaciones y widgets del BugBoard
+ */
+class BugBoard_Notifications {
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_action('admin_notices', array($this, 'show_pending_tasks_notice'));
+        add_action('wp_dashboard_setup', array($this, 'add_dashboard_widget'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_notification_scripts'));
+        add_action('admin_menu', array($this, 'add_menu_notifications'));
+    }
+
+    /**
+     * Mostrar notificación de tareas pendientes
+     */
+    public function show_pending_tasks_notice() {
+        // Solo mostrar a usuarios que pueden gestionar tareas
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $user_id = get_current_user_id();
+        $pending_tasks = $this->get_user_pending_tasks($user_id);
+        
+        if (empty($pending_tasks)) {
+            return;
+        }
+
+        // Verificar si ya se mostró la notificación hoy
+        $today = date('Y-m-d');
+        $last_notice = get_user_meta($user_id, 'bugboard_last_notice_date', true);
+        
+        if ($last_notice === $today) {
+            return;
+        }
+
+        // Guardar que se mostró la notificación hoy
+        update_user_meta($user_id, 'bugboard_last_notice_date', $today);
+
+        $task_count = count($pending_tasks);
+        
+        // Crear mensaje más detallado
+        $urgent_tasks = array_filter($pending_tasks, function($task) {
+            return $task['priority'] === 'alta';
+        });
+        
+        $message = sprintf(
+            'Tienes <strong>%d tarea%s pendiente%s</strong> en BugBoard',
+            $task_count,
+            $task_count === 1 ? '' : 's',
+            $task_count === 1 ? '' : 's'
+        );
+        
+        if (!empty($urgent_tasks)) {
+            $message .= sprintf(
+                ' (<strong>%d urgente%s</strong>)',
+                count($urgent_tasks),
+                count($urgent_tasks) === 1 ? '' : 's'
+            );
+        }
+        
+        $message .= sprintf(' <a href="%s">Ver tablero</a>', admin_url('admin.php?page=bugboard-tablero'));
+
+        echo '<div class="notice notice-info is-dismissible bugboard-notice">';
+        echo '<p>' . $message . '</p>';
+        echo '</div>';
+    }
+
+    /**
+     * Agregar widget al dashboard
+     */
+    public function add_dashboard_widget() {
+        // Solo mostrar a usuarios que pueden gestionar tareas
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        wp_add_dashboard_widget(
+            'bugboard_dashboard_widget',
+            'BugBoard - Mis Tareas',
+            array($this, 'render_dashboard_widget')
+        );
+    }
+
+    /**
+     * Renderizar widget del dashboard
+     */
+    public function render_dashboard_widget() {
+        $user_id = get_current_user_id();
+        $user_tasks = $this->get_user_tasks($user_id);
+        $stats = $this->get_user_task_stats($user_id);
+
+        ?>
+        <div class="bugboard-dashboard-widget">
+            <!-- Estadísticas rápidas -->
+            <div class="bugboard-stats-overview">
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $stats['total']; ?></span>
+                    <span class="stat-label">Total</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $stats['pending']; ?></span>
+                    <span class="stat-label">Pendientes</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $stats['in_progress']; ?></span>
+                    <span class="stat-label">En Progreso</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-number"><?php echo $stats['completed']; ?></span>
+                    <span class="stat-label">Completadas</span>
+                </div>
+            </div>
+
+            <!-- Tareas recientes -->
+            <?php if (!empty($user_tasks)): ?>
+                <div class="bugboard-recent-tasks">
+                    <h4>Tareas Recientes</h4>
+                    <ul class="bugboard-task-list">
+                        <?php foreach (array_slice($user_tasks, 0, 5) as $task): ?>
+                            <li class="bugboard-task-item priority-<?php echo $task['priority']; ?>">
+                                <div class="task-info">
+                                    <strong><?php echo esc_html($task['title']); ?></strong>
+                                    <span class="task-status"><?php echo $this->get_status_label($task['status']); ?></span>
+                                </div>
+                                <div class="task-meta">
+                                    <span class="task-priority"><?php echo strtoupper($task['priority']); ?></span>
+                                    <span class="task-date"><?php echo date('d/m/Y', strtotime($task['created_at'])); ?></span>
+                                </div>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php else: ?>
+                <p>No tienes tareas asignadas.</p>
+            <?php endif; ?>
+
+            <!-- Enlaces rápidos -->
+            <div class="bugboard-quick-links">
+                <a href="<?php echo admin_url('admin.php?page=bugboard-tablero'); ?>" class="button button-primary">
+                    Ver Tablero
+                </a>
+                <a href="<?php echo admin_url('admin.php?page=bugboard-tablero'); ?>" class="button" onclick="openTaskModal('por-hacer'); return false;">
+                    Nueva Tarea
+                </a>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Obtener tareas pendientes del usuario
+     */
+    private function get_user_pending_tasks($user_id) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        $query = $wpdb->prepare("
+            SELECT id, title, status, priority, created_at
+            FROM $table_tasks
+            WHERE assignee_id = %d 
+            AND status IN ('por-hacer', 'en-progreso', 'en-revision')
+            ORDER BY created_at DESC
+            LIMIT 10
+        ", $user_id);
+        
+        return $wpdb->get_results($query, ARRAY_A);
+    }
+
+    /**
+     * Obtener todas las tareas del usuario
+     */
+    private function get_user_tasks($user_id) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        $query = $wpdb->prepare("
+            SELECT id, title, status, priority, created_at
+            FROM $table_tasks
+            WHERE assignee_id = %d 
+            ORDER BY created_at DESC
+            LIMIT 10
+        ", $user_id);
+        
+        return $wpdb->get_results($query, ARRAY_A);
+    }
+
+    /**
+     * Obtener estadísticas de tareas del usuario
+     */
+    private function get_user_task_stats($user_id) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        $query = $wpdb->prepare("
+            SELECT 
+                COUNT(*) as total,
+                SUM(CASE WHEN status IN ('por-hacer', 'en-progreso', 'en-revision') THEN 1 ELSE 0 END) as pending,
+                SUM(CASE WHEN status = 'en-progreso' THEN 1 ELSE 0 END) as in_progress,
+                SUM(CASE WHEN status = 'completado' THEN 1 ELSE 0 END) as completed
+            FROM $table_tasks
+            WHERE assignee_id = %d
+        ", $user_id);
+        
+        $result = $wpdb->get_row($query, ARRAY_A);
+        
+        return array(
+            'total' => (int) $result['total'],
+            'pending' => (int) $result['pending'],
+            'in_progress' => (int) $result['in_progress'],
+            'completed' => (int) $result['completed']
+        );
+    }
+
+    /**
+     * Obtener etiqueta de estado
+     */
+    private function get_status_label($status) {
+        $labels = array(
+            'por-hacer' => 'Por Hacer',
+            'en-progreso' => 'En Progreso',
+            'en-revision' => 'En Revisión',
+            'completado' => 'Completado'
+        );
+        
+        return isset($labels[$status]) ? $labels[$status] : $status;
+    }
+
+    /**
+     * Agregar notificaciones al menú
+     */
+    public function add_menu_notifications() {
+        global $menu;
+        
+        // Solo mostrar a usuarios que pueden gestionar tareas
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        
+        $user_id = get_current_user_id();
+        $pending_tasks = $this->get_user_pending_tasks($user_id);
+        $task_count = count($pending_tasks);
+        
+        if ($task_count > 0) {
+            // Buscar el menú BugBoard y agregar el contador
+            foreach ($menu as $key => $item) {
+                if (isset($item[2]) && $item[2] === 'bugboard') {
+                    $menu[$key][0] .= " <span class='update-plugins count-{$task_count}'><span class='plugin-count'>{$task_count}</span></span>";
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Cargar scripts para notificaciones
+     */
+    public function enqueue_notification_scripts($hook) {
+        // Solo cargar en dashboard y páginas de BugBoard
+        if ($hook === 'index.php' || strpos($hook, 'bugboard') !== false) {
+            wp_enqueue_style(
+                'bugboard-notifications',
+                BUGBOARD_PLUGIN_URL . 'assets/css/notifications.css',
+                array(),
+                BUGBOARD_VERSION
+            );
+        }
+    }
+} 

--- a/bugboard/includes/class-bugboard-tablero.php
+++ b/bugboard/includes/class-bugboard-tablero.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Clase para manejar el tablero Kanban de BugBoard
+ * Clase para manejar el tablero Kanban
  */
 
 if (!defined('ABSPATH')) {
@@ -8,420 +8,360 @@ if (!defined('ABSPATH')) {
 }
 
 class BugBoard_Tablero {
-    
+
     /**
      * Constructor
      */
     public function __construct() {
-        error_log('BugBoard: Inicializando clase BugBoard_Tablero');
-        
-        // Registrar hooks AJAX
-        add_action('wp_ajax_bugboard_update_task_status', array($this, 'update_task_status'));
-        add_action('wp_ajax_bugboard_get_tasks', array($this, 'get_tasks'));
-        add_action('wp_ajax_nopriv_bugboard_get_tasks', array($this, 'get_tasks'));
-        
-        error_log('BugBoard: Hooks AJAX registrados');
+        add_action('admin_menu', array($this, 'add_admin_menu'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
     }
-    
+
     /**
-     * Registrar hooks AJAX (método separado para llamar desde el archivo principal)
+     * Añadir menú en el admin
      */
-    public function register_ajax_hooks() {
-        error_log('BugBoard: Registrando hooks AJAX...');
+    public function add_admin_menu() {
+        // Menú principal BugBoard
+        add_menu_page(
+            'BugBoard', // Título de la página
+            'BugBoard', // Título del menú
+            'manage_options', // Capacidad requerida
+            'bugboard', // Slug del menú
+            array($this, 'bugboard_main_page'), // Función callback
+            'dashicons-bug', // Icono
+            30 // Posición en el menú
+        );
         
-        add_action('wp_ajax_bugboard_update_task_status', array($this, 'update_task_status'));
-        add_action('wp_ajax_bugboard_get_tasks', array($this, 'get_tasks'));
-        add_action('wp_ajax_nopriv_bugboard_get_tasks', array($this, 'get_tasks'));
-        
-        // Función de prueba AJAX
-        add_action('wp_ajax_bugboard_test', array($this, 'test_ajax'));
-        add_action('wp_ajax_nopriv_bugboard_test', array($this, 'test_ajax'));
-        
-        // Función para obtener una tarea específica
-        add_action('wp_ajax_bugboard_get_task', array($this, 'get_task'));
-        add_action('wp_ajax_nopriv_bugboard_get_task', array($this, 'get_task'));
-        
-        // Función de prueba para get_task
-        add_action('wp_ajax_bugboard_test_get_task', array($this, 'test_get_task'));
-        add_action('wp_ajax_nopriv_bugboard_test_get_task', array($this, 'test_get_task'));
-        
-        // Función para eliminar una tarea
-        add_action('wp_ajax_bugboard_delete_task', array($this, 'delete_task'));
-        add_action('wp_ajax_nopriv_bugboard_delete_task', array($this, 'delete_task'));
-        
-        error_log('BugBoard: Hooks AJAX registrados correctamente');
+        // Submenú Tablero
+        add_submenu_page(
+            'bugboard', // Parent slug
+            'Tablero', // Título de la página
+            'Tablero', // Título del submenú
+            'manage_options', // Capacidad requerida
+            'bugboard-tablero', // Slug del submenú
+            array($this, 'bugboard_tablero_page') // Función callback
+        );
     }
-    
+
     /**
-     * Función de prueba AJAX
+     * Página principal de BugBoard
      */
-    public function test_ajax() {
-        error_log('BugBoard: test_ajax() llamada');
-        wp_send_json_success(array('message' => 'AJAX funciona correctamente'));
-    }
-    
-    /**
-     * Función de prueba para get_task
-     */
-    public function test_get_task() {
-        error_log('BugBoard: test_get_task() llamada');
-        error_log('BugBoard: POST data: ' . print_r($_POST, true));
-        wp_send_json_success(array('message' => 'get_task hook registrado correctamente'));
-    }
-    
-    /**
-     * Obtener una tarea específica
-     */
-    public function get_task() {
-        try {
-            error_log('BugBoard: get_task() llamada');
-            
-            // Verificar nonce
-            if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
-                wp_send_json_error(array('message' => 'Nonce inválido'));
-                return;
-            }
-            
-            // Obtener ID de la tarea
-            $task_id = intval($_POST['task_id']);
-            if (!$task_id) {
-                wp_send_json_error(array('message' => 'ID de tarea inválido'));
-                return;
-            }
-            
-            // Obtener la tarea
-            $task = get_post($task_id);
-            if (!$task || $task->post_type !== 'bug') {
-                wp_send_json_error(array('message' => 'Tarea no encontrada'));
-                return;
-            }
-            
-            // Obtener metadatos
-            $status = get_post_meta($task_id, '_bugboard_status', true);
-            $priority = get_post_meta($task_id, '_bugboard_priority', true);
-            $assignee = get_post_meta($task_id, '_bugboard_assignee', true);
-            
-            // Valores por defecto si no existen
-            if (empty($status)) $status = 'por-hacer';
-            if (empty($priority)) $priority = 'media';
-            
-            // Obtener información del autor de forma segura
-            $author_name = '';
-            if ($task->post_author) {
-                $author = get_userdata($task->post_author);
-                $author_name = $author ? $author->display_name : 'Usuario desconocido';
-            }
-            
-            // Obtener fecha de forma segura
-            $date = '';
-            if ($task->post_date) {
-                $date = date('d/m/Y', strtotime($task->post_date));
-            }
-            
-            $task_data = array(
-                'id' => $task_id,
-                'title' => $task->post_title,
-                'description' => $task->post_content,
-                'status' => $status,
-                'priority' => $priority,
-                'assignee' => $assignee,
-                'author' => $author_name,
-                'date' => $date
-            );
-            
-            wp_send_json_success($task_data);
-            
-        } catch (Exception $e) {
-            error_log('BugBoard: Error en get_task: ' . $e->getMessage());
-            wp_send_json_error(array('message' => 'Error interno: ' . $e->getMessage()));
-        }
-    }
-    
-    /**
-     * Eliminar una tarea
-     */
-    public function delete_task() {
-        try {
-            error_log('BugBoard: delete_task() llamada');
-            
-            // Verificar nonce
-            if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
-                wp_send_json_error(array('message' => 'Nonce inválido'));
-                return;
-            }
-            
-            // Obtener ID de la tarea
-            $task_id = intval($_POST['task_id']);
-            if (!$task_id) {
-                wp_send_json_error(array('message' => 'ID de tarea inválido'));
-                return;
-            }
-            
-            // Verificar que la tarea existe y es del tipo correcto
-            $task = get_post($task_id);
-            if (!$task || $task->post_type !== 'bug') {
-                wp_send_json_error(array('message' => 'Tarea no encontrada'));
-                return;
-            }
-            
-            // Eliminar la tarea
-            $result = wp_delete_post($task_id, true); // true = eliminar permanentemente
-            
-            if ($result) {
-                error_log('BugBoard: Tarea eliminada correctamente');
-                wp_send_json_success(array('message' => 'Tarea eliminada correctamente'));
-            } else {
-                error_log('BugBoard: Error al eliminar tarea');
-                wp_send_json_error(array('message' => 'Error al eliminar la tarea'));
-            }
-            
-        } catch (Exception $e) {
-            error_log('BugBoard: Error en delete_task: ' . $e->getMessage());
-            wp_send_json_error(array('message' => 'Error interno: ' . $e->getMessage()));
-        }
-    }
-    
-    /**
-     * Renderizar el tablero Kanban
-     */
-    public function render_tablero() {
+    public function bugboard_main_page() {
         ?>
         <div class="wrap">
-            <h1>Tablero de Tareas</h1>
-            <button id="debug-load-tasks" class="button">Debug: Cargar Tareas</button>
-            <button id="debug-test-ajax" class="button">Debug: Probar AJAX</button>
-            <button id="debug-test-get-task" class="button">Debug: Probar Get Task</button>
-            <div id="debug-info" style="margin: 10px 0; padding: 10px; background: #f0f0f0; border-radius: 4px;"></div>
+            <h1>BugBoard</h1>
+            <p>Bienvenido al plugin BugBoard para gestión de tareas.</p>
             
-            <div class="bugboard-tablero">
-                <div class="bugboard-columns">
-                    <!-- Columna: Por Hacer -->
-                    <div class="bugboard-column" data-status="por-hacer">
-                        <div class="bugboard-column-header">
-                            <h3>Por Hacer</h3>
-                            <span class="task-count">0</span>
-                        </div>
-                        <div class="bugboard-tasks" id="por-hacer-tasks">
-                            <!-- Las tareas se cargarán aquí -->
-                        </div>
-                        <button class="add-task-btn" data-status="por-hacer">+ Añadir Tarea</button>
+            <div class="bugboard-dashboard">
+                <h2>Estadísticas</h2>
+                <?php $this->display_stats(); ?>
+            </div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Mostrar estadísticas
+     */
+    private function display_stats() {
+        $stats = BugBoard_Tasks::get_task_stats();
+        $current_user_id = get_current_user_id();
+        $user_stats = $this->get_user_task_stats($current_user_id);
+        $current_user = wp_get_current_user();
+        ?>
+        
+        <!-- Estadísticas Generales -->
+        <div class="bugboard-stats-section">
+            <h3>📊 Estadísticas Generales</h3>
+            <div class="bugboard-stats">
+                <div class="stat-card">
+                    <h3>Por Hacer</h3>
+                    <span class="stat-number"><?php echo $stats['por-hacer']; ?></span>
+                </div>
+                <div class="stat-card">
+                    <h3>En Progreso</h3>
+                    <span class="stat-number"><?php echo $stats['en-progreso']; ?></span>
+                </div>
+                <div class="stat-card">
+                    <h3>En Revisión</h3>
+                    <span class="stat-number"><?php echo $stats['en-revision']; ?></span>
+                </div>
+                <div class="stat-card">
+                    <h3>Completado</h3>
+                    <span class="stat-number"><?php echo $stats['completado']; ?></span>
+                </div>
+                <div class="stat-card total">
+                    <h3>Total</h3>
+                    <span class="stat-number"><?php echo $stats['total']; ?></span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Estadísticas del Usuario Actual -->
+        <div class="bugboard-stats-section">
+            <h3>👤 Mis Tareas - <?php echo esc_html($current_user->display_name); ?></h3>
+            <div class="bugboard-user-stats">
+                <div class="user-stat-card">
+                    <div class="stat-icon">📋</div>
+                    <div class="stat-content">
+                        <h4>Total Asignadas</h4>
+                        <span class="stat-number"><?php echo $user_stats['total']; ?></span>
                     </div>
-                    
-                    <!-- Columna: En Progreso -->
-                    <div class="bugboard-column" data-status="en-progreso">
-                        <div class="bugboard-column-header">
-                            <h3>En Progreso</h3>
-                            <span class="task-count">0</span>
-                        </div>
-                        <div class="bugboard-tasks" id="en-progreso-tasks">
-                            <!-- Las tareas se cargarán aquí -->
-                        </div>
-                        <button class="add-task-btn" data-status="en-progreso">+ Añadir Tarea</button>
+                </div>
+                <div class="user-stat-card pending">
+                    <div class="stat-icon">⏳</div>
+                    <div class="stat-content">
+                        <h4>Pendientes</h4>
+                        <span class="stat-number"><?php echo $user_stats['pending']; ?></span>
                     </div>
-                    
-                    <!-- Columna: En Revisión -->
-                    <div class="bugboard-column" data-status="en-revision">
-                        <div class="bugboard-column-header">
-                            <h3>En Revisión</h3>
-                            <span class="task-count">0</span>
-                        </div>
-                        <div class="bugboard-tasks" id="en-revision-tasks">
-                            <!-- Las tareas se cargarán aquí -->
-                        </div>
-                        <button class="add-task-btn" data-status="en-revision">+ Añadir Tarea</button>
+                </div>
+                <div class="user-stat-card in-progress">
+                    <div class="stat-icon">🔄</div>
+                    <div class="stat-content">
+                        <h4>En Progreso</h4>
+                        <span class="stat-number"><?php echo $user_stats['in_progress']; ?></span>
                     </div>
-                    
-                    <!-- Columna: Completado -->
-                    <div class="bugboard-column" data-status="completado">
-                        <div class="bugboard-column-header">
-                            <h3>Completado</h3>
-                            <span class="task-count">0</span>
-                        </div>
-                        <div class="bugboard-tasks" id="completado-tasks">
-                            <!-- Las tareas se cargarán aquí -->
-                        </div>
-                        <button class="add-task-btn" data-status="completado">+ Añadir Tarea</button>
+                </div>
+                <div class="user-stat-card completed">
+                    <div class="stat-icon">✅</div>
+                    <div class="stat-content">
+                        <h4>Completadas</h4>
+                        <span class="stat-number"><?php echo $user_stats['completed']; ?></span>
+                    </div>
+                </div>
+                <div class="user-stat-card urgent">
+                    <div class="stat-icon">🚨</div>
+                    <div class="stat-content">
+                        <h4>Urgentes</h4>
+                        <span class="stat-number"><?php echo $user_stats['urgent']; ?></span>
                     </div>
                 </div>
             </div>
             
-            <!-- Modal para añadir/editar tareas -->
-            <div id="task-modal" class="bugboard-modal">
+            <!-- Progreso del usuario -->
+            <?php if ($user_stats['total'] > 0): ?>
+                <div class="user-progress">
+                    <h4>Progreso Personal</h4>
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: <?php echo ($user_stats['completed'] / $user_stats['total']) * 100; ?>%"></div>
+                    </div>
+                    <span class="progress-text"><?php echo round(($user_stats['completed'] / $user_stats['total']) * 100); ?>% completado</span>
+                </div>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * Página del tablero
+     */
+    public function bugboard_tablero_page() {
+        ?>
+        <div class="wrap">
+            <h1>Tablero Kanban - BugBoard</h1>
+            
+            <div id="debug-info" style="background: #f0f0f0; padding: 10px; margin: 10px 0; border-radius: 4px; font-family: monospace; font-size: 12px;">
+                <strong>Debug:</strong> Cargando tareas...
+            </div>
+            
+            <div class="bugboard-columns">
+                <div class="bugboard-column" data-status="por-hacer">
+                    <div class="bugboard-column-header">
+                        <h3>Por Hacer</h3>
+                        <span class="task-count">0</span>
+                    </div>
+                    <div class="bugboard-tasks">
+                        <!-- Las tareas se cargarán aquí -->
+                        <div class="empty-column-message" style="display: none;">
+                            <p>No hay tareas pendientes</p>
+                            <small>Arrastra tareas aquí o crea una nueva</small>
+                        </div>
+                    </div>
+                    <button class="add-task-btn" onclick="openTaskModal('por-hacer')">+ Añadir Tarea</button>
+                </div>
+                
+                <div class="bugboard-column" data-status="en-progreso">
+                    <div class="bugboard-column-header">
+                        <h3>En Progreso</h3>
+                        <span class="task-count">0</span>
+                    </div>
+                    <div class="bugboard-tasks">
+                        <!-- Las tareas se cargarán aquí -->
+                        <div class="empty-column-message" style="display: none;">
+                            <p>No hay tareas en progreso</p>
+                            <small>Arrastra tareas aquí o crea una nueva</small>
+                        </div>
+                    </div>
+                    <button class="add-task-btn" onclick="openTaskModal('en-progreso')">+ Añadir Tarea</button>
+                </div>
+                
+                <div class="bugboard-column" data-status="en-revision">
+                    <div class="bugboard-column-header">
+                        <h3>En Revisión</h3>
+                        <span class="task-count">0</span>
+                    </div>
+                    <div class="bugboard-tasks">
+                        <!-- Las tareas se cargarán aquí -->
+                        <div class="empty-column-message" style="display: none;">
+                            <p>No hay tareas en revisión</p>
+                            <small>Arrastra tareas aquí o crea una nueva</small>
+                        </div>
+                    </div>
+                    <button class="add-task-btn" onclick="openTaskModal('en-revision')">+ Añadir Tarea</button>
+                </div>
+                
+                <div class="bugboard-column" data-status="completado">
+                    <div class="bugboard-column-header">
+                        <h3>Completado</h3>
+                        <span class="task-count">0</span>
+                    </div>
+                    <div class="bugboard-tasks">
+                        <!-- Las tareas se cargarán aquí -->
+                        <div class="empty-column-message" style="display: none;">
+                            <p>No hay tareas completadas</p>
+                            <small>Arrastra tareas aquí o crea una nueva</small>
+                        </div>
+                    </div>
+                    <button class="add-task-btn" onclick="openTaskModal('completado')">+ Añadir Tarea</button>
+                </div>
+            </div>
+            
+            <!-- Modal para crear/editar tareas -->
+            <div id="task-modal" class="bugboard-modal" style="display: none;">
                 <div class="bugboard-modal-content">
-                    <span class="bugboard-modal-close">&times;</span>
+                    <span class="bugboard-modal-close" onclick="closeTaskModal()">&times;</span>
                     <h2 id="modal-title">Añadir Nueva Tarea</h2>
+                    
                     <form id="task-form">
                         <input type="hidden" id="task-id" name="task_id" value="">
-                        <input type="hidden" id="task-status" name="task_status" value="">
                         
                         <div class="form-group">
-                            <label for="task-title">Título de la Tarea</label>
-                            <input type="text" id="task-title" name="task_title" required>
+                            <label for="task-title">Título:</label>
+                            <input type="text" id="task-title" name="title" required>
                         </div>
                         
                         <div class="form-group">
-                            <label for="task-description">Descripción</label>
-                            <textarea id="task-description" name="task_description" rows="4"></textarea>
+                            <label for="task-description">Descripción:</label>
+                            <textarea id="task-description" name="description" rows="4"></textarea>
+                        </div>
+                        
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="task-status">Estado:</label>
+                                <select id="task-status" name="status" required>
+                                    <option value="por-hacer">Por Hacer</option>
+                                    <option value="en-progreso">En Progreso</option>
+                                    <option value="en-revision">En Revisión</option>
+                                    <option value="completado">Completado</option>
+                                </select>
+                            </div>
+                            
+                            <div class="form-group">
+                                <label for="task-priority">Prioridad:</label>
+                                <select id="task-priority" name="priority" required>
+                                    <option value="baja">Baja</option>
+                                    <option value="media" selected>Media</option>
+                                    <option value="alta">Alta</option>
+                                    <option value="critica">Crítica</option>
+                                </select>
+                            </div>
+                        </div>
+                        
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="task-assignee">Asignado a:</label>
+                                <select id="task-assignee" name="assignee">
+                                    <option value="">Sin asignar</option>
+                                    <?php
+                                    $users = BugBoard_Tasks::get_available_users();
+                                    foreach ($users as $user) {
+                                        echo '<option value="' . $user['id'] . '">' . esc_html($user['name']) . '</option>';
+                                    }
+                                    ?>
+                                </select>
+                            </div>
+                            
+                            <div class="form-group">
+                                <label for="task-due-date">Fecha límite:</label>
+                                <input type="date" id="task-due-date" name="due_date">
+                            </div>
                         </div>
                         
                         <div class="form-group">
-                            <label for="task-priority">Prioridad</label>
-                            <select id="task-priority" name="task_priority">
-                                <option value="baja">Baja</option>
-                                <option value="media">Media</option>
-                                <option value="alta">Alta</option>
-                            </select>
-                        </div>
-                        
-                        <div class="form-group">
-                            <label for="task-assignee">Asignado a</label>
-                            <select id="task-assignee" name="task_assignee">
-                                <option value="">Sin asignar</option>
-                                <?php
-                                $users = get_users(array('role__in' => array('administrator', 'editor')));
-                                foreach ($users as $user) {
-                                    echo '<option value="' . $user->ID . '">' . $user->display_name . '</option>';
-                                }
-                                ?>
-                            </select>
+                            <label for="task-estimated-hours">Horas estimadas:</label>
+                            <input type="number" id="task-estimated-hours" name="estimated_hours" min="0" step="0.5">
                         </div>
                         
                         <div class="form-actions">
-                            <button type="submit" class="button button-primary">Guardar Tarea</button>
+                            <button type="submit" class="button button-primary">Guardar</button>
                             <button type="button" class="button" onclick="closeTaskModal()">Cancelar</button>
                         </div>
                     </form>
                 </div>
             </div>
         </div>
-        
-        <script>
-        // Variables globales para el tablero
-        var bugboardAjaxUrl = '<?php echo admin_url('admin-ajax.php'); ?>';
-        var bugboardNonce = '<?php echo wp_create_nonce('bugboard_nonce'); ?>';
-        console.log('BugBoard Debug - AJAX URL:', bugboardAjaxUrl);
-        console.log('BugBoard Debug - Nonce:', bugboardNonce);
-        </script>
         <?php
     }
-    
+
     /**
-     * Obtener tareas para el tablero
+     * Obtener estadísticas de tareas del usuario
      */
-    public function get_tasks() {
-        try {
-            // Debug: log de la función
-            error_log('BugBoard: get_tasks() llamada');
-            
-            // Verificar que se recibieron los datos POST
-            if (!isset($_POST['nonce'])) {
-                error_log('BugBoard: No se recibió nonce');
-                wp_send_json_error(array('message' => 'No se recibió nonce'));
-                return;
-            }
-            
-            // Verificar nonce
-            if (!wp_verify_nonce($_POST['nonce'], 'bugboard_nonce')) {
-                error_log('BugBoard: Nonce inválido');
-                wp_send_json_error(array('message' => 'Nonce inválido'));
-                return;
-            }
-            
-            error_log('BugBoard: Nonce válido, procediendo...');
-            
-            // Obtener todas las tareas del tipo 'bug'
-            $tasks = get_posts(array(
-                'post_type' => 'bug',
-                'post_status' => 'publish',
-                'numberposts' => -1
-            ));
-            
-            error_log('BugBoard: Encontradas ' . count($tasks) . ' tareas');
-            
-            $formatted_tasks = array();
-            foreach ($tasks as $task) {
-                $status = get_post_meta($task->ID, '_bugboard_status', true);
-                $priority = get_post_meta($task->ID, '_bugboard_priority', true);
-                $assignee = get_post_meta($task->ID, '_bugboard_assignee', true);
-                
-                // Si no tiene estado asignado, asignar 'por-hacer' por defecto
-                if (empty($status)) {
-                    $status = 'por-hacer';
-                    update_post_meta($task->ID, '_bugboard_status', $status);
-                }
-                
-                // Si no tiene prioridad asignada, asignar 'media' por defecto
-                if (empty($priority)) {
-                    $priority = 'media';
-                    update_post_meta($task->ID, '_bugboard_priority', $priority);
-                }
-                
-                $formatted_tasks[] = array(
-                    'id' => $task->ID,
-                    'title' => $task->post_title,
-                    'description' => $task->post_content,
-                    'status' => $status,
-                    'priority' => $priority,
-                    'assignee' => $assignee,
-                    'author' => get_the_author_meta('display_name', $task->post_author),
-                    'date' => get_the_date('d/m/Y', $task->ID)
-                );
-            }
-            
-            error_log('BugBoard: Enviando ' . count($formatted_tasks) . ' tareas formateadas');
-            wp_send_json_success($formatted_tasks);
-            
-        } catch (Exception $e) {
-            error_log('BugBoard: Error en get_tasks: ' . $e->getMessage());
-            wp_send_json_error(array('message' => 'Error interno: ' . $e->getMessage()));
-        }
-    }
-    
-    /**
-     * Actualizar estado de una tarea
-     */
-    public function update_task_status() {
-        check_ajax_referer('bugboard_nonce', 'nonce');
+    private function get_user_task_stats($user_id) {
+        global $wpdb;
         
-        $task_id = intval($_POST['task_id']);
-        $new_status = sanitize_text_field($_POST['status']);
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
         
-        if (update_post_meta($task_id, '_bugboard_status', $new_status)) {
-            wp_send_json_success(array('message' => 'Estado actualizado correctamente'));
-        } else {
-            wp_send_json_error(array('message' => 'Error al actualizar el estado'));
-        }
-    }
-    
-    /**
-     * Crear o actualizar una tarea
-     */
-    public function save_task($task_data) {
-        $task_id = isset($task_data['task_id']) ? intval($task_data['task_id']) : 0;
+        $query = $wpdb->prepare("
+            SELECT 
+                COUNT(*) as total,
+                SUM(CASE WHEN status IN ('por-hacer', 'en-progreso', 'en-revision') THEN 1 ELSE 0 END) as pending,
+                SUM(CASE WHEN status = 'en-progreso' THEN 1 ELSE 0 END) as in_progress,
+                SUM(CASE WHEN status = 'completado' THEN 1 ELSE 0 END) as completed,
+                SUM(CASE WHEN priority = 'alta' THEN 1 ELSE 0 END) as urgent
+            FROM $table_tasks
+            WHERE assignee_id = %d
+        ", $user_id);
         
-        $post_data = array(
-            'post_title' => sanitize_text_field($task_data['task_title']),
-            'post_content' => wp_kses_post($task_data['task_description']),
-            'post_type' => 'bug',
-            'post_status' => 'publish'
+        $result = $wpdb->get_row($query, ARRAY_A);
+        
+        return array(
+            'total' => (int) $result['total'],
+            'pending' => (int) $result['pending'],
+            'in_progress' => (int) $result['in_progress'],
+            'completed' => (int) $result['completed'],
+            'urgent' => (int) $result['urgent']
         );
-        
-        if ($task_id > 0) {
-            $post_data['ID'] = $task_id;
-            $post_id = wp_update_post($post_data);
-        } else {
-            $post_id = wp_insert_post($post_data);
-        }
-        
-        if ($post_id) {
-            // Guardar metadatos
-            update_post_meta($post_id, '_bugboard_status', sanitize_text_field($task_data['task_status']));
-            update_post_meta($post_id, '_bugboard_priority', sanitize_text_field($task_data['task_priority']));
-            update_post_meta($post_id, '_bugboard_assignee', sanitize_text_field($task_data['task_assignee']));
+    }
+
+    /**
+     * Cargar scripts y estilos del admin
+     */
+    public function enqueue_admin_scripts($hook) {
+        // Solo cargar en páginas de BugBoard
+        if (strpos($hook, 'bugboard') !== false) {
+            wp_enqueue_style(
+                'bugboard-admin-style',
+                BUGBOARD_PLUGIN_URL . 'assets/css/admin.css',
+                array(),
+                BUGBOARD_VERSION
+            );
             
-            return $post_id;
+            // Cargar JavaScript solo en la página del tablero
+            if (strpos($hook, 'bugboard-tablero') !== false || $hook === 'bugboard_page_bugboard-tablero') {
+                wp_enqueue_script(
+                    'bugboard-tablero-js',
+                    BUGBOARD_PLUGIN_URL . 'assets/js/tablero.js',
+                    array('jquery'),
+                    BUGBOARD_VERSION,
+                    true
+                );
+                
+                // Localizar script con variables necesarias
+                wp_localize_script('bugboard-tablero-js', 'bugboardAjax', array(
+                    'ajaxurl' => admin_url('admin-ajax.php'),
+                    'nonce' => wp_create_nonce('bugboard_nonce')
+                ));
+            }
         }
-        
-        return false;
     }
 } 

--- a/bugboard/includes/class-bugboard-tasks.php
+++ b/bugboard/includes/class-bugboard-tasks.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Clase para manejar las tareas del BugBoard
+ */
+class BugBoard_Tasks {
+
+    /**
+     * Obtener todas las tareas
+     */
+    public static function get_all_tasks() {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        $table_users = $wpdb->users;
+        
+        $query = "
+            SELECT 
+                t.id,
+                t.title,
+                t.description,
+                t.status,
+                t.priority,
+                t.assignee_id,
+                t.author_id,
+                t.created_at,
+                t.updated_at,
+                t.due_date,
+                t.estimated_hours,
+                assignee.display_name as assignee_name,
+                author.display_name as author_name
+            FROM $table_tasks t
+            LEFT JOIN $table_users assignee ON t.assignee_id = assignee.ID
+            LEFT JOIN $table_users author ON t.author_id = author.ID
+            ORDER BY t.created_at DESC
+        ";
+        
+        return $wpdb->get_results($query, ARRAY_A);
+    }
+
+    /**
+     * Obtener una tarea específica
+     */
+    public static function get_task($task_id) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        $table_users = $wpdb->users;
+        
+        $query = $wpdb->prepare("
+            SELECT 
+                t.id,
+                t.title,
+                t.description,
+                t.status,
+                t.priority,
+                t.assignee_id,
+                t.author_id,
+                t.created_at,
+                t.updated_at,
+                t.due_date,
+                t.estimated_hours,
+                assignee.display_name as assignee_name,
+                author.display_name as author_name
+            FROM $table_tasks t
+            LEFT JOIN $table_users assignee ON t.assignee_id = assignee.ID
+            LEFT JOIN $table_users author ON t.author_id = author.ID
+            WHERE t.id = %d
+        ", $task_id);
+        
+        return $wpdb->get_row($query, ARRAY_A);
+    }
+
+    /**
+     * Crear una nueva tarea
+     */
+    public static function create_task($data) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        $defaults = array(
+            'title' => '',
+            'description' => '',
+            'status' => 'por-hacer',
+            'priority' => 'media',
+            'assignee_id' => null,
+            'author_id' => get_current_user_id(),
+            'due_date' => null,
+            'estimated_hours' => null
+        );
+        
+        $data = wp_parse_args($data, $defaults);
+        
+        // Validar datos requeridos
+        if (empty($data['title'])) {
+            return new WP_Error('title_required', 'El título es obligatorio');
+        }
+        
+        // Insertar la tarea
+        $result = $wpdb->insert(
+            $table_tasks,
+            $data,
+            array('%s', '%s', '%s', '%s', '%d', '%d', '%s', '%f')
+        );
+        
+        if ($result === false) {
+            return new WP_Error('insert_failed', 'Error al crear la tarea');
+        }
+        
+        return $wpdb->insert_id;
+    }
+
+    /**
+     * Actualizar una tarea
+     */
+    public static function update_task($task_id, $data) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        // Validar que la tarea existe
+        $existing_task = self::get_task($task_id);
+        if (!$existing_task) {
+            return new WP_Error('task_not_found', 'Tarea no encontrada');
+        }
+        
+        // Actualizar la tarea
+        $result = $wpdb->update(
+            $table_tasks,
+            $data,
+            array('id' => $task_id),
+            null,
+            array('%d')
+        );
+        
+        if ($result === false) {
+            return new WP_Error('update_failed', 'Error al actualizar la tarea');
+        }
+        
+        return true;
+    }
+
+    /**
+     * Eliminar una tarea
+     */
+    public static function delete_task($task_id) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        // Validar que la tarea existe
+        $existing_task = self::get_task($task_id);
+        if (!$existing_task) {
+            return new WP_Error('task_not_found', 'Tarea no encontrada');
+        }
+        
+        // Eliminar la tarea
+        $result = $wpdb->delete(
+            $table_tasks,
+            array('id' => $task_id),
+            array('%d')
+        );
+        
+        if ($result === false) {
+            return new WP_Error('delete_failed', 'Error al eliminar la tarea');
+        }
+        
+        return true;
+    }
+
+    /**
+     * Actualizar el estado de una tarea
+     */
+    public static function update_task_status($task_id, $new_status) {
+        $valid_statuses = array('por-hacer', 'en-progreso', 'en-revision', 'completado');
+        
+        if (!in_array($new_status, $valid_statuses)) {
+            return new WP_Error('invalid_status', 'Estado no válido');
+        }
+        
+        return self::update_task($task_id, array('status' => $new_status));
+    }
+
+    /**
+     * Obtener tareas por estado
+     */
+    public static function get_tasks_by_status($status) {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        $table_users = $wpdb->users;
+        
+        $query = $wpdb->prepare("
+            SELECT 
+                t.id,
+                t.title,
+                t.description,
+                t.status,
+                t.priority,
+                t.assignee_id,
+                t.author_id,
+                t.created_at,
+                t.updated_at,
+                t.due_date,
+                t.estimated_hours,
+                assignee.display_name as assignee_name,
+                author.display_name as author_name
+            FROM $table_tasks t
+            LEFT JOIN $table_users assignee ON t.assignee_id = assignee.ID
+            LEFT JOIN $table_users author ON t.author_id = author.ID
+            WHERE t.status = %s
+            ORDER BY t.created_at DESC
+        ", $status);
+        
+        return $wpdb->get_results($query, ARRAY_A);
+    }
+
+    /**
+     * Obtener estadísticas de tareas
+     */
+    public static function get_task_stats() {
+        global $wpdb;
+        
+        $table_tasks = $wpdb->prefix . 'bugboard_tasks';
+        
+        $query = "
+            SELECT 
+                status,
+                COUNT(*) as count
+            FROM $table_tasks
+            GROUP BY status
+        ";
+        
+        $results = $wpdb->get_results($query, ARRAY_A);
+        
+        $stats = array(
+            'por-hacer' => 0,
+            'en-progreso' => 0,
+            'en-revision' => 0,
+            'completado' => 0,
+            'total' => 0
+        );
+        
+        foreach ($results as $row) {
+            $stats[$row['status']] = (int) $row['count'];
+            $stats['total'] += (int) $row['count'];
+        }
+        
+        return $stats;
+    }
+
+    /**
+     * Obtener usuarios disponibles para asignación
+     */
+    public static function get_available_users() {
+        $users = get_users(array(
+            'orderby' => 'display_name',
+            'order' => 'ASC'
+        ));
+        
+        $available_users = array();
+        foreach ($users as $user) {
+            $available_users[] = array(
+                'id' => $user->ID,
+                'name' => $user->display_name,
+                'email' => $user->user_email
+            );
+        }
+        
+        return $available_users;
+    }
+
+    /**
+     * Formatear datos de tarea para el frontend
+     */
+    public static function format_task_for_frontend($task) {
+        return array(
+            'id' => $task['id'],
+            'title' => $task['title'],
+            'description' => $task['description'],
+            'status' => $task['status'],
+            'priority' => $task['priority'],
+            'assignee_id' => $task['assignee_id'],
+            'assignee_name' => $task['assignee_name'] ?: 'Sin asignar',
+            'author_id' => $task['author_id'],
+            'author_name' => $task['author_name'],
+            'created_at' => $task['created_at'],
+            'updated_at' => $task['updated_at'],
+            'due_date' => $task['due_date'],
+            'estimated_hours' => $task['estimated_hours']
+        );
+    }
+} 


### PR DESCRIPTION
- Add BugBoard_Notifications class for admin notices
- Add dashboard widget with user task statistics
- Add menu badge counter for pending tasks
- Add user-specific statistics to main page
- Add progress bar for user task completion
- Add responsive CSS for notifications and stats
- Show notifications only once per day per user
- Add detailed user task breakdown (total, pending, in-progress, completed, urgent)